### PR TITLE
Add doxygen to appveyor and travis-ci tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,16 +6,19 @@ init:
   - SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
 
 install:
+  - choco install -y doxygen.portable
   - python -m pip install setuptools wheel
   - python -m pip install -r requirements.txt
 
 build: false
 
 test_script:
+  - doxygen --version
   - python -V
   - python -m pip -V
   - make html
   - python rebuild_readme.py
+  - doxygen
 
 cache:
   - '%LOCALAPPDATA%\pip\Cache'

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ install:
 script:
   - make html
   - python rebuild_readme.py
+  - doxygen
   - mkdir -p ${BUILD_PATH}
   - cp -Rv build/* $BUILD_PATH
   - cp -Rv docs/* $BUILD_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,18 @@ python:
   - 3.5
   - 3.6
 
+addons:
+  apt:
+    packages:
+      - doxygen
+
 cache:
   pip: true
   directories:
     - $HOME/.cache/pre-commit
     - $HOME/.pre-commit
     - $HOME/Library/Caches/Homebrew
+    - $HOME/.ccache
 
 env:
   global:
@@ -56,10 +62,12 @@ install:
       eval "$(pyenv init -)"
       pyenv install --skip-existing --keep --verbose ${TRAVIS_PYTHON_VERSION}
       pyenv shell ${TRAVIS_PYTHON_VERSION}
-      python -V
+      brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb;
     fi
   - pip install -U pip setuptools wheel
   - pip install -r requirements.txt
+  - python -V
+  - doxygen --version
 
 script:
   - make html


### PR DESCRIPTION
Ajoute les tests de build doxygen, et fonctionne sur : 
- [x] appveyor (Windows) ;
- [x] travis (Linux) ;
- [x] travis (MacOS X).

Closes #40.