### PR TITLE
Hide menu options whenever a canvas gets open in foreground

### DIFF
--- a/Assets/Menu/MenuForegroundCanvas.cs
+++ b/Assets/Menu/MenuForegroundCanvas.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+namespace Menu {
+    public class MenuForegroundCanvas : MonoBehaviour {
+        /// <summary>
+        /// The main menu options container, it will allow to toggle the visibility.
+        /// </summary>
+        public GameObject MainMenu;
+
+        /// <summary>
+        /// When the option canvas gets displayed, hide the main menu.
+        /// </summary>
+        private void OnEnable() {
+            this.MainMenu.SetActive(false);
+        }
+
+        /// <summary>
+        /// When the option canvas gets hidden, restore the main menu.
+        /// </summary>
+        private void OnDisable() {
+            this.MainMenu.SetActive(true);
+        }
+    }
+}

--- a/Assets/Menu/MenuForegroundCanvas.cs.meta
+++ b/Assets/Menu/MenuForegroundCanvas.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e0374b9f940240dfaa99f1da4280cb12
+timeCreated: 1542225391

--- a/Assets/Menu/OptionsCanvas.cs
+++ b/Assets/Menu/OptionsCanvas.cs
@@ -6,7 +6,7 @@ namespace Menu {
     /// This class manages a options canvas,
     /// and will disable itself if the user hits "Cancel" (e.g.: escape key).
     /// </summary>
-    public class OptionsCanvas : MonoBehaviour {
+    public class OptionsCanvas : MenuForegroundCanvas {
         /// <summary>
         /// Disable itself (<code>gameObject.SetActive(false)</code>)
         /// if the user hits "Cancel".

--- a/Assets/Scenes/MainMenuScene.unity
+++ b/Assets/Scenes/MainMenuScene.unity
@@ -869,11 +869,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 542105743}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.73, z: 9.52}
-  m_LocalScale: {x: 0.12, y: 0.12, z: 0.12}
+  m_LocalRotation: {x: 0.00000006778658, y: -0.9818721, z: 0.189545, w: 0.0000003511448}
+  m_LocalPosition: {x: -0, y: 2.2600331, z: -0.9063502}
+  m_LocalScale: {x: 0.120000176, y: 0.12000002, z: 0.120000094}
   m_Children: []
-  m_Father: {fileID: 651611703}
+  m_Father: {fileID: 1687060369}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!102 &542105745
@@ -1198,6 +1198,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b52d00eb36a74cfc8120fe0f509f125e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  MainMenu: {fileID: 1687060368}
 --- !u!1 &568727100
 GameObject:
   m_ObjectHideFlags: 0
@@ -1487,11 +1488,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 8.97, z: 22.92}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1937479115}
-  - {fileID: 542105744}
-  - {fileID: 1277090204}
-  - {fileID: 749214830}
-  - {fileID: 2142765292}
+  - {fileID: 1687060369}
   m_Father: {fileID: 1157050711}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1522,11 +1519,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 749214829}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.4, z: 9.52}
-  m_LocalScale: {x: 0.12000012, y: 0.12000003, z: 0.120000064}
+  m_LocalRotation: {x: 0.00000006778658, y: -0.9818721, z: 0.189545, w: 0.0000003511448}
+  m_LocalPosition: {x: 0, y: 0.28308445, z: -0.113524444}
+  m_LocalScale: {x: 0.120000295, y: 0.12000004, z: 0.12000016}
   m_Children: []
-  m_Father: {fileID: 651611703}
+  m_Father: {fileID: 1687060369}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!82 &749214831
@@ -2161,11 +2158,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1277090203}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.67, z: 9.52}
-  m_LocalScale: {x: 0.12000006, y: 0.12000001, z: 0.120000035}
+  m_LocalRotation: {x: 0.00000006778658, y: -0.9818721, z: 0.189545, w: 0.0000003511448}
+  m_LocalPosition: {x: -0, y: 1.2761995, z: -0.51179945}
+  m_LocalScale: {x: 0.120000236, y: 0.120000035, z: 0.120000124}
   m_Children: []
-  m_Father: {fileID: 651611703}
+  m_Father: {fileID: 1687060369}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!82 &1277090205
@@ -3003,6 +3000,39 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1687060368
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1687060369}
+  m_Layer: 0
+  m_Name: Menu Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1687060369
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1687060368}
+  m_LocalRotation: {x: -0.00000006778658, y: 0.9818721, z: -0.189545, w: 0.0000003511448}
+  m_LocalPosition: {x: 0, y: -0.70499945, z: 9.520002}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1937479115}
+  - {fileID: 542105744}
+  - {fileID: 1277090204}
+  - {fileID: 749214830}
+  - {fileID: 2142765292}
+  m_Father: {fileID: 651611703}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1918401317
 GameObject:
   m_ObjectHideFlags: 0
@@ -3152,11 +3182,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1937479114}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 2.78, z: 9.52}
-  m_LocalScale: {x: 0.1200001, y: 0.12000001, z: 0.12000006}
+  m_LocalRotation: {x: 0.00000006778658, y: -0.9818721, z: 0.189545, w: 0.0000003511448}
+  m_LocalPosition: {x: -0, y: 3.2345862, z: -1.2971792}
+  m_LocalScale: {x: 0.12000028, y: 0.120000035, z: 0.120000154}
   m_Children: []
-  m_Father: {fileID: 651611703}
+  m_Father: {fileID: 1687060369}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!82 &1937479116
@@ -3576,11 +3606,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2142765291}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: -4.19, z: 9.52}
-  m_LocalScale: {x: 0.12000012, y: 0.12000001, z: 0.12000006}
+  m_LocalRotation: {x: 0.00000006778658, y: -0.9818721, z: 0.189545, w: 0.0000003511448}
+  m_LocalPosition: {x: 0, y: -3.2345867, z: 1.2971795}
+  m_LocalScale: {x: 0.120000295, y: 0.120000035, z: 0.120000154}
   m_Children: []
-  m_Father: {fileID: 651611703}
+  m_Father: {fileID: 1687060369}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2142765294


### PR DESCRIPTION
### Issue associée <!-- required -->
Closes #69   <!-- le numéro à fermer ; gardez le mot 'Closes' en anglais -->

### Changements
<!-- La liste des changements faits et tout autre commentaire... -->
Ajoute un canvas de base qui cache le menu dès lorsqu'il passe au premier-plan.


### Pull Request Checklist
<!-- Merci de garder cette section. Cela rendra la vie du mainteneur plus facile. -->

1. [x] Le code est optimisé et lisible.
1. [x] Les changements sont testés.
1. [x] Le code est documenté (docstrings, commentaires, documentation du project).
